### PR TITLE
Splitting main loop in a fetcher-and-worker model

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -390,7 +390,7 @@ func (jq *JobQueue) maybeNext() (int64, bool, error) {
 	rows, err := jq.db.Query(`
 		select id from job_queue
 		where status = ? and remaining > 0 and schedulable_at <= ?
-		order by id asc limit 1`,
+		order by schedulable_at asc limit 1`,
 		statusPending, now)
 	if err != nil {
 		return -1, false, err

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -255,24 +255,6 @@ func (s *JobsSuite) TestMaybeNext(c *C) {
 	c.Assert(hasNext, Equals, false)
 }
 
-func (s *JobsSuite) TestNextAndLock(c *C) {
-	s.setAutoId("job_queue", 123)
-
-	rec, err := s.jq.nextAndLock()
-	c.Assert(err, IsNil)
-	c.Assert(rec, IsNil)
-
-	s.inTx(func(tx *sql.Tx) {
-		_, err = s.jq.Enqueue(tx, "name_of_job", nil)
-		c.Assert(err, IsNil)
-	})
-
-	rec, err = s.jq.nextAndLock()
-	c.Assert(err, IsNil)
-	c.Assert(rec, NotNil)
-	c.Assert(rec.id, Equals, int64(123))
-}
-
 func (s *JobsSuite) TestReEnqueue(c *C) {
 	s.setAutoId("job_queue", 123)
 


### PR DESCRIPTION
- Fetchers are responsible for pulling potential jobs to work on from the persistent queue in the DB, and place them in an in-memory channel;
- Workers take jobs from the in-memory channel, attempt to lock them, and if successful, can proceed to process them.

The idea is that workers are fed what to work on, while other pieces can be responsible for deciding what jobs should be attemped. We could imagine placing jobs in the queue using other triggers than simply the DB, such as a post-commit hook on enqueuing which would speed up the discovery of a job and shorten the enqueue-to-completion timeframe.

cc @genecyber