### PR TITLE
Fetcher performs job locking

### DIFF
--- a/jobs_test.go
+++ b/jobs_test.go
@@ -204,26 +204,45 @@ func (s *JobsSuite) TestAttemptLock_decreasesRemaining(c *C) {
 	c.Assert(rec.remaining, Equals, conf.attempts-1)
 }
 
-func (s *JobsSuite) TestAttemptLock_concurrentModification(c *C) {
+func (s *JobsSuite) TestFetcherExecutesAttemptLock(c *C) {
 	var (
 		jobId int64
 		err   error
 	)
+
+	// clear queue
+	_, err = s.db.Exec("truncate table job_queue")
+	c.Assert(err, IsNil)
+
+	// clear channel
+	s.jq.maybeJobIds = make(chan int64)
 
 	s.inTx(func(tx *sql.Tx) {
 		jobId, err = s.jq.Enqueue(tx, "name_of_job", nil)
 		c.Assert(err, IsNil)
 	})
 
-	// Let's assume another worked raced us to process the job.
-	_, err = s.db.Exec("update job_queue set status = ? where id = ?",
-		statusProcessing, jobId)
+	// mark queue as running
+	atomic.StoreInt32(s.jq.status, queueRunning)
+	go s.jq.fetcher(0)
+	nextJobId := <-s.jq.maybeJobIds
+
+	// test that fetcher sent expected jobId to maybeJobIds
+	c.Assert(nextJobId, Equals, jobId)
+
+	var status string
+	err = s.jq.db.
+		QueryRow(
+			"select status from job_queue where id = ?",
+			jobId).
+		Scan(&status)
 	c.Assert(err, IsNil)
 
-	// Now, we shouldn't be able to lock.
-	locked, err := s.jq.attemptLock(jobId)
-	c.Assert(err, IsNil)
-	c.Assert(locked, Equals, false)
+	// test that fetcher locked the jobId
+	c.Assert(status, Equals, statusProcessing)
+
+	// stop fetcher
+	atomic.StoreInt32(s.jq.status, queueStopping)
 }
 
 func (s *JobsSuite) TestMaybeNext(c *C) {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -210,9 +210,10 @@ func (s *JobsSuite) TestFetcherExecutesAttemptLock(c *C) {
 		err   error
 	)
 
-	// clear queue
-	_, err = s.db.Exec("truncate table job_queue")
+	// queue is clear
+	jobId, hasNext, err := s.jq.maybeNext()
 	c.Assert(err, IsNil)
+	c.Assert(hasNext, Equals, false)
 
 	// clear channel
 	s.jq.maybeJobIds = make(chan int64)


### PR DESCRIPTION
### Fixes race condition 
where after a fetcher sent a `jobId` to`maybeJobIds`, if a worker did not lock it before a fetcher read from the DB again, the same `jobId` would be processed multiple times.


### To Do (unrelated)
If `Stop` is called too soon after `Start`, workers may still be being `Add`ed to the `workersWg` while `workersWg.Wait()` is in the process of resolving, leading to

PANIC: jobs_test.go:394: JobsSuite.TestStartStop

... Panic: sync: WaitGroup is reused before previous Wait has returned (PC=0x105A5EA)

/usr/local/Cellar/go/1.9.2/libexec/src/runtime/panic.go:491
  in gopanic
/usr/local/Cellar/go/1.9.2/libexec/src/sync/waitgroup.go:133
  in WaitGroup.Wait
jobs.go:305
  in JobQueue.Stop
jobs_test.go:405
  in JobsSuite.TestStartStop
/usr/local/Cellar/go/1.9.2/libexec/src/reflect/value.go:302
  in Value.Call
/usr/local/Cellar/go/1.9.2/libexec/src/runtime/asm_amd64.s:2337
  in goexit
OOPS: 15 passed, 1 PANICKED
--- FAIL: Test (5.20s)